### PR TITLE
Add 'pick: matchbox' component

### DIFF
--- a/components/matchBox/AwayteamLogo.tsx
+++ b/components/matchBox/AwayteamLogo.tsx
@@ -5,5 +5,5 @@ export type Logo = {
 };
 
 export default function AwayteamLogo({ logo }: Logo) {
-  return <img className={`${styles.awayteamLogo}`} src={logo} />;
+  return <img className={styles.awayteamLogo} src={logo} />;
 }

--- a/components/matchBox/AwayteamLogo.tsx
+++ b/components/matchBox/AwayteamLogo.tsx
@@ -1,0 +1,9 @@
+import styles from "./MatchBox.module.css";
+
+export type Logo = {
+  logo: string;
+};
+
+export default function AwayteamLogo({ logo }: Logo) {
+  return <img className={`${styles.awayteamLogo}`} src={logo} />;
+}

--- a/components/matchBox/AwayteamLogo.tsx
+++ b/components/matchBox/AwayteamLogo.tsx
@@ -4,6 +4,6 @@ export type Logo = {
   logo: string;
 };
 
-export default function AwayteamLogo({ logo }: Logo) {
+export default function AwayTeamLogo({ logo }: Logo) {
   return <img className={styles.awayteamLogo} src={logo} />;
 }

--- a/components/matchBox/HometeamLogo.tsx
+++ b/components/matchBox/HometeamLogo.tsx
@@ -5,5 +5,5 @@ export type Logo = {
 };
 
 export default function HometeamLogo({ logo }: Logo) {
-  return <img className={`${styles.hometeamLogo}`} src={logo} />;
+  return <img className={styles.hometeamLogo} src={logo} />;
 }

--- a/components/matchBox/HometeamLogo.tsx
+++ b/components/matchBox/HometeamLogo.tsx
@@ -4,6 +4,6 @@ export type Logo = {
   logo: string;
 };
 
-export default function HometeamLogo({ logo }: Logo) {
+export default function HomeTeamLogo({ logo }: Logo) {
   return <img className={styles.hometeamLogo} src={logo} />;
 }

--- a/components/matchBox/HometeamLogo.tsx
+++ b/components/matchBox/HometeamLogo.tsx
@@ -1,0 +1,9 @@
+import styles from "./MatchBox.module.css";
+
+export type Logo = {
+  logo: string;
+};
+
+export default function HometeamLogo({ logo }: Logo) {
+  return <img className={`${styles.hometeamLogo}`} src={logo} />;
+}

--- a/components/matchBox/MatchBox.module.css
+++ b/components/matchBox/MatchBox.module.css
@@ -1,0 +1,30 @@
+.matchBox,
+.matchBoxUnselected {
+  display: grid;
+
+  /* grid-template-areas: "hometeamLogo teamnames awayteamLogo"; */
+  background-color: var(--secondary-color);
+  height: 2.75rem;
+  width: 24.35rem;
+  border-radius: 50px;
+}
+
+.matchBoxUnselected {
+  opacity: 50%;
+}
+
+.teamnames {
+  grid-area: teamnames;
+  color: var(--primary-color);
+  margin: 0;
+}
+
+/* .hometeamLogo {
+  grid-area: hometeamLogo;
+  height: 1.875rem;
+}
+
+.awayteamLogo {
+  grid-area: awayteamLogo;
+  height: 1.875rem;
+} */

--- a/components/matchBox/MatchBox.module.css
+++ b/components/matchBox/MatchBox.module.css
@@ -13,7 +13,7 @@
   opacity: 50%;
 }
 
-.teamnames {
+.teamNames {
   grid-area: teamnames;
   color: var(--primary-color);
   margin: 0;

--- a/components/matchBox/MatchBox.stories.tsx
+++ b/components/matchBox/MatchBox.stories.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { Story, Meta } from "@storybook/react/types-6-0";
+import MatchBox, { MatchBoxProps } from "./MatchBox";
+
+export default {
+  title: "Common/MatchBox",
+  component: MatchBox,
+} as Meta;
+
+const Template: Story<MatchBoxProps> = (args) => <MatchBox {...args} />;
+
+export const Primary = Template.bind({});
+Primary.args = {
+  // awayteamLogo: "https://crests.football-data.org/4.svg",
+  awayteam: "Dortmund",
+  // hometeamLogo: "https://crests.football-data.org/1.svg",
+  hometeam: "Köln",
+};

--- a/components/matchBox/MatchBox.stories.tsx
+++ b/components/matchBox/MatchBox.stories.tsx
@@ -12,7 +12,7 @@ const Template: Story<MatchBoxProps> = (args) => <MatchBox {...args} />;
 export const Primary = Template.bind({});
 Primary.args = {
   // awayteamLogo: "https://crests.football-data.org/4.svg",
-  awayteam: "Dortmund",
+  awayTeam: "Dortmund",
   // hometeamLogo: "https://crests.football-data.org/1.svg",
-  hometeam: "Köln",
+  homeTeam: "Köln",
 };

--- a/components/matchBox/MatchBox.tsx
+++ b/components/matchBox/MatchBox.tsx
@@ -12,8 +12,8 @@ export type MatchBoxProps = {
 
 export default function MatchBox({
   // hometeamLogo,
-  hometeam,
-  awayteam,
+  homeTeam,
+  awayTeam,
 }: // awayteamLogo,
 MatchBoxProps) {
   return (

--- a/components/matchBox/MatchBox.tsx
+++ b/components/matchBox/MatchBox.tsx
@@ -17,8 +17,8 @@ export default function MatchBox({
 }: // awayteamLogo,
 MatchBoxProps) {
   return (
-    <div className={`${styles.matchBox}`}>
-      <p className={`${styles.teamnames}`}>
+    <div className={styles.matchBox}>
+      <p className={styles.teamnames}>
         {/* <HometeamLogo logo={hometeamLogo} /> */}
         <Teamnames home={hometeam} away={awayteam} />
         {/* <AwayteamLogo logo={awayteamLogo} /> */}

--- a/components/matchBox/MatchBox.tsx
+++ b/components/matchBox/MatchBox.tsx
@@ -1,0 +1,28 @@
+import styles from "./MatchBox.module.css";
+// import HometeamLogo from "./HometeamLogo";
+// import AwayteamLogo from "./AwayteamLogo";
+import Teamnames from "./TeamNames";
+
+export type MatchBoxProps = {
+  // hometeamLogo: string;
+  hometeam: string;
+  // awayteamLogo: string;
+  awayteam: string;
+};
+
+export default function MatchBox({
+  // hometeamLogo,
+  hometeam,
+  awayteam,
+}: // awayteamLogo,
+MatchBoxProps) {
+  return (
+    <div className={`${styles.matchBox}`}>
+      <p className={`${styles.teamnames}`}>
+        {/* <HometeamLogo logo={hometeamLogo} /> */}
+        <Teamnames home={hometeam} away={awayteam} />
+        {/* <AwayteamLogo logo={awayteamLogo} /> */}
+      </p>
+    </div>
+  );
+}

--- a/components/matchBox/MatchBox.tsx
+++ b/components/matchBox/MatchBox.tsx
@@ -5,9 +5,9 @@ import Teamnames from "./TeamNames";
 
 export type MatchBoxProps = {
   // hometeamLogo: string;
-  hometeam: string;
+  homeTeam: string;
   // awayteamLogo: string;
-  awayteam: string;
+  awayTeam: string;
 };
 
 export default function MatchBox({
@@ -18,9 +18,9 @@ export default function MatchBox({
 MatchBoxProps) {
   return (
     <div className={styles.matchBox}>
-      <p className={styles.teamnames}>
+      <p className={styles.teamNames}>
         {/* <HometeamLogo logo={hometeamLogo} /> */}
-        <Teamnames home={hometeam} away={awayteam} />
+        <Teamnames home={homeTeam} away={awayTeam} />
         {/* <AwayteamLogo logo={awayteamLogo} /> */}
       </p>
     </div>

--- a/components/matchBox/TeamNames.tsx
+++ b/components/matchBox/TeamNames.tsx
@@ -1,0 +1,14 @@
+import styles from "./MatchBox.module.css";
+
+export type Teams = {
+  home: string;
+  away: string;
+};
+
+export default function Teamnames({ home, away }: Teams) {
+  return (
+    <p className={`${styles.teamnames}`}>
+      {home} vs. {away}
+    </p>
+  );
+}

--- a/components/matchBox/TeamNames.tsx
+++ b/components/matchBox/TeamNames.tsx
@@ -7,7 +7,7 @@ export type Teams = {
 
 export default function Teamnames({ home, away }: Teams) {
   return (
-    <p className={`${styles.teamnames}`}>
+    <p className={styles.teamnames}>
       {home} vs. {away}
     </p>
   );

--- a/components/matchBox/TeamNames.tsx
+++ b/components/matchBox/TeamNames.tsx
@@ -5,7 +5,7 @@ export type Teams = {
   away: string;
 };
 
-export default function Teamnames({ home, away }: Teams) {
+export default function TeamNames({ home, away }: Teams) {
   return (
     <p className={styles.teamnames}>
       {home} vs. {away}

--- a/components/matchBox/TeamNames.tsx
+++ b/components/matchBox/TeamNames.tsx
@@ -7,7 +7,7 @@ export type Teams = {
 
 export default function TeamNames({ home, away }: Teams) {
   return (
-    <p className={styles.teamnames}>
+    <p className={styles.teamNames}>
       {home} vs. {away}
     </p>
   );


### PR DESCRIPTION
- 🔨 Add awayteam logo
- 🔨 Add hometeam logo
- 🔨 Add teamnames
- 💄 Add styling
- 🔨 Add MatchBox
- Add storybook

The respective logos should be displayed to the left and right of the team names. However, I have not managed to position them independently of the team names in such a way that I am satisfied with them and have therefore temporarily decided to shelve the issue. 
I have commented out all code in this regard and will address the issue again later. The current code is not pretty, but it currently serves its purpose 🌚

[Deployment](https://king-of-the-matchbox-4te0a7o3o.herokuapp.com/storybook/index.html?path=/story/common-matchbox--primary)
